### PR TITLE
Support for paper type selection in CUPS driver for M110

### DIFF
--- a/cups/drv/phomemo-m110.drv
+++ b/cups/drv/phomemo-m110.drv
@@ -45,9 +45,9 @@
   *Resolution - 8 0 0 0 203dpi
   ColorModel Gray/Grayscale w chunky 0
 
-  *MediaType 10 "Label With Gaps"
+  *MediaType 10 "LabelWithGaps/Label With Gaps"
   MediaType 11 "Continuas"
-  MediaType 38 "Label With Marks"
+  MediaType 38 "LabelWithMarks/Label With Marks"
 
   MediaSize "w20h100"
   MediaSize "w20h10"

--- a/cups/drv/phomemo-m110.drv
+++ b/cups/drv/phomemo-m110.drv
@@ -45,6 +45,10 @@
   *Resolution - 8 0 0 0 203dpi
   ColorModel Gray/Grayscale w chunky 0
 
+  *MediaType 10 "Label With Gaps"
+  MediaType 11 "Continuas"
+  MediaType 38 "Label With Marks"
+
   MediaSize "w20h100"
   MediaSize "w20h10"
   MediaSize "w20h20"

--- a/cups/filter/rastertopm110.py
+++ b/cups/filter/rastertopm110.py
@@ -75,17 +75,17 @@ def select_density(file, density = 10):
     file.write(density.to_bytes(1, 'little'))
     return
 
-def select_media_type(file, media_type = b'\x0a'):
+def select_media_type(file):
     # media_type : b'\x0a'="Label With Gaps" b'\x0b'="Contenuas" b'\x26'="Label With Marks"
     file.write(b'\x1f' + b'\x11') # select Media Type, 
     file.write(media_type)
     return
 
-def print_header(file):
+def print_header(file, media_type = b'\x0a'):
     printer_init(file)
     select_speed(file, 5)
     select_density(file, 10)
-    select_media_type(file, b'\x0a')
+    select_media_type(file, media_type)
     return
 
 def print_raster(file, image, line, lines = 0xff, mode = 0):
@@ -120,7 +120,7 @@ for i, datatuple in enumerate(pages):
 
     line = 0
     with os.fdopen(sys.stdout.fileno(), "wb", closefd=False) as stdout:
-        print_header(stdout)
+        print_header(stdout,header.MediaType)
         while line < im.height:
             lines = im.height - line
             if lines > 255:

--- a/cups/filter/rastertopm110.py
+++ b/cups/filter/rastertopm110.py
@@ -75,13 +75,12 @@ def select_density(file, density = 10):
     file.write(density.to_bytes(1, 'little'))
     return
 
-def select_media_type(file):
-    # media_type : b'\x0a'="Label With Gaps" b'\x0b'="Contenuas" b'\x26'="Label With Marks"
+def select_media_type(file, media_type):
     file.write(b'\x1f' + b'\x11') # select Media Type, 
-    file.write(media_type)
+    file.write(media_type.to_bytes(1, 'little'))
     return
 
-def print_header(file, media_type = b'\x0a'):
+def print_header(file, media_type = 10):
     printer_init(file)
     select_speed(file, 5)
     select_density(file, 10)
@@ -120,7 +119,7 @@ for i, datatuple in enumerate(pages):
 
     line = 0
     with os.fdopen(sys.stdout.fileno(), "wb", closefd=False) as stdout:
-        print_header(stdout,header.MediaType)
+        print_header(stdout,header.cupsMediaType)
         while line < im.height:
             lines = im.height - line
             if lines > 255:


### PR DESCRIPTION
Hi! 
Phomemo M110 has a three modes to supports three paper types: label, continuous paper and label with marker. I have modified the .drv and filter for M110 to allow user to select the mode of paper type via the CUPS driver. 
I would be happy to merge them if you would like.
Thanks.