### PR TITLE
Update README.md for M220 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Phomemo-tools
 
 This package is trying to provide tools to print pictures using
-the Phomemo M02, M110 and M120 thermal printers from Linux.
+the Phomemo M02, M110, M120 and M220 thermal printers from Linux.
 
 All the information here has been reverse-engineered sniffing
 the bluetooth packets emitted by the Android application.
@@ -161,50 +161,33 @@ Click on "Add a Printer...".
 
 #### 2.2.2. CLI
 ##### 2.2.2.1. Bluetooth
+This definition will use the "phomemo" backend to connect to the printer:
+
 ###### 2.2.2.1.1 M02
-
-This definition will use the "phomemo" backend to connect to the M02 printer:
-
 ```
   $ sudo lpadmin -p M02 -E -v phomemo://DC0D309023C7 \
                            -P /usr/share/cups/model/Phomemo/Phomemo-M02.ppd.gz
 ```
-###### 2.2.2.1.2 M110
-This definition will use the "phomemo" backend to connect to the M110 printer:
-
+###### 2.2.2.1.2 M110, M120, M220
+Use ”Phomemo-M110.ppd.gz”. This driver is compatible with M110, M120, and M220.
+The -p option defines the printer name. It should be changed according to the printer used.
 ```
   $ sudo lpadmin -p M110 -E -v phomemo://DC0D309023C7 \
                            -P /usr/share/cups/model/Phomemo/Phomemo-M110.ppd.gz
 ```
-###### 2.2.2.1.3 M120
-This definition will use the "phomemo" backend to connect to the M120 printer (keep in mind the M120 printer uses the same drivers as the M110):
-
-```
-  $ sudo lpadmin -p M120 -E -v phomemo://DC0D309023C7 \
-                           -P /usr/share/cups/model/Phomemo/Phomemo-M110.ppd.gz
-```
 
 ##### 2.2.2.2. USB
-###### 2.2.2.2.1 M02
-
 This definition will use the /dev/usb/lp0 device to connect to the printer:
-
+###### 2.2.2.2.1 M02
 ```
   $ sudo lpadmin -p M02 -E -v serial:/dev/usb/lp0 \
                            -P /usr/share/cups/model/Phomemo/Phomemo-M02.ppd.gz
 ```
-###### 2.2.2.1.2 M110
-This definition will use the /dev/usb/lp0 device to connect to the M110 printer:
-
+###### 2.2.2.1.2 M110, M120, M220
+Use ”Phomemo-M110.ppd.gz”. This driver is compatible with M110, M120, and M220.
+The -p option defines the printer name. It should be changed according to the printer used.
 ```
-  $ sudo lpadmin -p M110 -E -v phomemo:/dev/usb/lp0 \
-                           -P /usr/share/cups/model/Phomemo/Phomemo-M110.ppd.gz
-```
-###### 2.2.2.1.3 M120
-This definition will use the /dev/usb/lp0 device to connect to the M120 printer (keep in mind the M120 printer uses the same drivers as the M110):
-
-```
-  $ sudo lpadmin -p M120 -E -v phomemo:/dev/usb/lp0 \
+  $ sudo lpadmin -p M110 -E -v serial:/dev/usb/lp0 \
                            -P /usr/share/cups/model/Phomemo/Phomemo-M110.ppd.gz
 ```
 
@@ -225,7 +208,7 @@ You can use the following command to print an image using CUPS:
 ```
   $ lp -d M02 -o media=w50h60 my_picture.png
 ```
-The M110 & M120 printers have support for LabelWithGaps, Continuous and LabelWithMarks media types which can be specified as follows:
+The M110, M120 & M220 printers have support for LabelWithGaps, Continuous and LabelWithMarks media types which can be specified as follows:
 
 ```
   $ echo "This is test"  | lp -d M110 -o media=w30h20 -o MediaType=Continuous
@@ -286,7 +269,7 @@ After dumpping bluetooth packets, it appears to be EPSON ESC/POS Commands.
 51 30 30 31 45 30 XX XX XX XX XX XX XX XX XX -> Serial Numer: E05C0XXXXXX
 ```
 
-## 4. Protocol for M110/M120
+## 4. Protocol for M110/M120/M220
 
 Dumpping USB packets. 
 


### PR DESCRIPTION
Reorganize M110 subsections and Add M220. Fix minor errors.
Since adding subsections for each model makes it difficult to read, the models that use the same driver are grouped into a single subsections. 
Fixed a typo in the USB connection procedure that specified the Phomemo backend.