### PR TITLE
Use native Python sockets for Bluetooth

### DIFF
--- a/cups/backend/phomemo.py
+++ b/cups/backend/phomemo.py
@@ -4,7 +4,7 @@ import sys
 import os
 import subprocess
 import dbus
-from bluetooth import *
+import socket
 import usb.core
 import usb.util
 
@@ -98,14 +98,13 @@ print('DEBUG: ' + sys.argv[0] +' device ' + bdaddr)
 
 try:
     print('STATE: +connecting-to-device')
-    sock = BluetoothSocket(RFCOMM)
-    sock.bind(('00:00:00:00:00:00', 0))
+    sock = socket.socket(socket.AF_BLUETOOTH, proto=socket.BTPROTO_RFCOMM)
     sock.connect((bdaddr, 1))
     print('STATE: +sending-data')
     with os.fdopen(sys.stdin.fileno(), 'rb', closefd=False) as stdin:
         sent = sock.send(stdin.read())
         print('DEBUG: sent %d' % (sent))
-except BluetoothError as btErr:
+except OSError as btErr:
     print("ERROR: Can't open Bluetooth connection: " + str(btErr), file=sys.stderr)
     exit(1)
 try:


### PR DESCRIPTION
Since PyBluez is deprecated and the latest version is from four years ago, this pull request switches to the native Python socket library to connect to the printer.

Python supports connecting a RFCOMM socket via Bluetooth at least since version 3.4, so it should be safe to completely switch to this variant.

Additionally, the call to `bind()` doesn't seem necessary (anymore), so it has been removed. Reading the response from the printer worked in my tests without it.