### PR TITLE
Old M220 fixes and added support for 70mm wide tapes 

### DIFF
--- a/cups/Makefile
+++ b/cups/Makefile
@@ -8,7 +8,9 @@ install:
 	install -D ppd/Phomemo-M02.ppd.gz -t $(DESTDIR)/usr/share/cups/model/Phomemo
 	install -D ppd/Phomemo-T02.ppd.gz -t $(DESTDIR)/usr/share/cups/model/Phomemo
 	install -D drv/phomemo-m110.drv -t $(DESTDIR)/usr/share/cups/drv/
+	install -D drv/phomemo-m220.drv -t $(DESTDIR)/usr/share/cups/drv/
 	install -D ppd/Phomemo-M110.ppd.gz -t $(DESTDIR)/usr/share/cups/model/Phomemo
+	install -D ppd/Phomemo-M220.ppd.gz -t $(DESTDIR)/usr/share/cups/model/Phomemo
 	install -Dm 755 filter/rastertopm02_t02.py $(DESTDIR)/usr/lib/cups/filter/rastertopm02_t02
 	install -Dm 755 filter/rastertopm110.py $(DESTDIR)/usr/lib/cups/filter/rastertopm110
 	install -Dm 755 backend/phomemo.py $(DESTDIR)/usr/lib/cups/backend/phomemo

--- a/cups/drv/phomemo-m220.drv
+++ b/cups/drv/phomemo-m220.drv
@@ -1,0 +1,79 @@
+//
+// Driver info file for Phomemo M110
+//
+// Copyright © 2020 Laurent Vivier <laurent@vivier.eu>
+//
+
+#include <font.defs>
+#include <media.defs>
+#include <label.h>
+
+#media "w20h100/Label 20mmx100mm" 20mm 100mm
+#media "w20h10/Label 20mmx10mm" 20mm 10mm
+#media "w20h20/Label 20mmx20mm" 20mm 20mm
+#media "w25h10/Label 25mmx10mm" 25mm 10mm
+#media "w25h30/Label 25mmx30mm" 25mm 30mm
+#media "w25h38/Label 25mmx38mm" 25mm 38mm
+#media "w30h20/Label 30mmx20mm" 30mm 20mm
+#media "w30h25/Label 30mmx25mm" 30mm 25mm
+#media "w30h30/Label 30mmx30mm" 30mm 30mm
+#media "w35h15/Label 35mmx15mm" 35mm 15mm
+#media "w40h20/Label 40mmx20mm" 40mm 20mm
+#media "w40h30/Label 40mmx30mm" 40mm 30mm
+#media "w40h40/Label 40mmx40mm" 40mm 40mm
+#media "w40h60/Label 40mmx60mm" 40mm 60mm
+#media "w40h80/Label 40mmx80mm" 40mm 80mm
+#media "w45h60/Label 45mmx60mm" 45mm 60mm
+#media "w50h20/Label 50mmx20mm" 50mm 20mm
+#media "w50h30/Label 50mmx30mm" 50mm 30mm
+#media "w50h50/Label 50mmx50mm" 50mm 50mm
+#media "w50h70/Label 50mmx70mm" 50mm 70mm
+#media "w50h80/Label 50mmx80mm" 50mm 80mm
+#media "w70h80/Label 70mmx80mm" 70mm 80mm
+
+{
+  Manufacturer "Phomemo"
+  ModelName "M220"
+  PCFileName "Phomemo-M220.ppd"
+  Version 1.0
+  Attribute "NickName" "" "Phomemo M220"
+  DriverType label
+  ColorDevice No
+  Attribute "cupsSNMPSupplies" "" "false"
+  HWMargins 1mm 0 1mm 0
+
+  Filter "application/vnd.cups-raster 100 rastertopm110"
+  *Resolution - 8 0 0 0 203dpi
+  ColorModel Gray/Grayscale w chunky 0
+
+  *MediaType 10 "LabelWithGaps/Label With Gaps"
+  MediaType 11 "Continuous"
+  MediaType 38 "LabelWithMarks/Label With Marks"
+
+  MediaSize "w20h100"
+  MediaSize "w20h10"
+  MediaSize "w20h20"
+  MediaSize "w25h10"
+  MediaSize "w25h30"
+  MediaSize "w25h38"
+  MediaSize "w30h20"
+  MediaSize "w30h25"
+  MediaSize "w30h30"
+  MediaSize "w35h15"
+  MediaSize "w40h20"
+  *MediaSize "w40h30"
+  MediaSize "w40h40"
+  MediaSize "w40h60"
+  MediaSize "w40h80"
+  MediaSize "w45h60"
+  MediaSize "w50h20"
+  MediaSize "w50h30"
+  MediaSize "w50h50"
+  MediaSize "w50h70"
+  MediaSize "w50h80"
+  MediaSize "w70h80"
+
+  VariablePaperSize Yes
+  MinSize 0.00 0.00
+  MaxSize 0.00 0.00
+}

--- a/cups/filter/rastertopm110.py
+++ b/cups/filter/rastertopm110.py
@@ -61,10 +61,6 @@ def read_ras3(rdata):
 
     return pages
 
-def printer_init(file):
-    file.write(ESC + b'@') # initialize printer
-    return
-
 def select_speed(file, speed = 5):
     file.write(ESC + b'\x4e' + b'\x0d') # select Print Speed
     file.write(speed.to_bytes(1, 'little'))
@@ -81,7 +77,6 @@ def select_media_type(file, media_type):
     return
 
 def print_header(file, media_type = 10):
-    printer_init(file)
     select_speed(file, 5)
     select_density(file, 10)
     select_media_type(file, media_type)
@@ -118,12 +113,9 @@ for i, datatuple in enumerate(pages):
     im = im.convert('1')
 
     line = 0
+    
     with os.fdopen(sys.stdout.fileno(), "wb", closefd=False) as stdout:
         print_header(stdout,header.cupsMediaType)
-        while line < im.height:
-            lines = im.height - line
-            if lines > 255:
-                lines = 255
-            print_raster(stdout, im, line, lines)
-            line += lines
+        lines = im.height
+        print_raster(stdout, im, line, lines)
         print_footer(stdout) 


### PR DESCRIPTION
This PR has fixes to work bettter with M220 printers.

* The key fix is the work done by @bleriotx in https://github.com/vivier/phomemo-tools/pull/15.  However, I've merged their three commits into one per a request by @vivier.

But I've also added a second commit that splits out the M220 drv/ppd as its own printer type (rather than using the M110 definition).  This was necessary to add support for 70mm wide tapes (which I think the M110 doesn't support?).  

Here's an example image of such a tape:
![tape](https://github.com/user-attachments/assets/e4ce124a-0451-49f0-bcd5-afd99a7dad33)


