### PR TITLE
Add support for Phomemo D30

### DIFF
--- a/cups/Makefile
+++ b/cups/Makefile
@@ -7,10 +7,13 @@ install:
 	install -D drv/phomemo-m02_t02.drv -t $(DESTDIR)/usr/share/cups/drv/
 	install -D ppd/Phomemo-M02.ppd.gz -t $(DESTDIR)/usr/share/cups/model/Phomemo
 	install -D ppd/Phomemo-T02.ppd.gz -t $(DESTDIR)/usr/share/cups/model/Phomemo
+	install -D ppd/Phomemo-D30.ppd.gz -t $(DESTDIR)/usr/share/cups/model/Phomemo
 	install -D drv/phomemo-m110.drv -t $(DESTDIR)/usr/share/cups/drv/
 	install -D drv/phomemo-m220.drv -t $(DESTDIR)/usr/share/cups/drv/
+	install -D drv/phomemo-d30.drv -t $(DESTDIR)/usr/share/cups/drv/
 	install -D ppd/Phomemo-M110.ppd.gz -t $(DESTDIR)/usr/share/cups/model/Phomemo
 	install -D ppd/Phomemo-M220.ppd.gz -t $(DESTDIR)/usr/share/cups/model/Phomemo
 	install -Dm 755 filter/rastertopm02_t02.py $(DESTDIR)/usr/lib/cups/filter/rastertopm02_t02
 	install -Dm 755 filter/rastertopm110.py $(DESTDIR)/usr/lib/cups/filter/rastertopm110
+	install -Dm 755 filter/rastertopd30.py $(DESTDIR)/usr/lib/cups/filter/rastertopd30
 	install -Dm 755 backend/phomemo.py $(DESTDIR)/usr/lib/cups/backend/phomemo

--- a/cups/drv/phomemo-d30.drv
+++ b/cups/drv/phomemo-d30.drv
@@ -1,0 +1,41 @@
+//
+// Driver info file for Phomemo M02/T02
+//
+// Copyright © 2020 Laurent Vivier <laurent@vivier.eu>
+//
+
+#include <font.defs>
+#include <media.defs>
+#include <label.h>
+
+#media "w40h12/Label 12mmx40mm" 40mm 12mm
+#media "w30h14/Label 14mmx30mm" 30mm 14mm
+
+Manufacturer "Phomemo"
+Version 2.0
+DriverType label
+ColorDevice No
+Attribute "cupsSNMPSupplies" "" "false"
+HWMargins 1mm 0 1mm 0
+
+Filter "application/vnd.cups-raster 100 rastertopd30"
+*Resolution - 8 0 0 0 203dpi
+ColorModel Gray/Grayscale w chunky 0
+
+*MediaSize "w40h12"
+MediaSize "w30h14"
+
+VariablePaperSize Yes
+MinSize 0.00 0.00
+MaxSize 0.00 0.00
+
+Option "FeedLines/Feed Lines for Tearing" PickOne DocumentSetup 20.0
+Attribute CustomFeedLines True "<</AdvanceDistance 3 -1 roll>>setpagedevice"
+Attribute ParamCustomFeedLines Lines "1 int 0 20"
+{
+  Attribute "NickName" "" "Phomemo D30"
+  ModelName "D30"
+  PCFileName "Phomemo-D30.ppd"
+  Option "FeedLines" PickOne DocumentSetup 20.0
+  *Choice "Default/Default (2)" "<</AdvanceDistance 2>>setpagedevice"
+}

--- a/cups/filter/rastertopd30.py
+++ b/cups/filter/rastertopd30.py
@@ -1,0 +1,103 @@
+#! /usr/bin/env python3
+
+import sys, os
+from collections import namedtuple
+from struct import unpack
+
+from PIL import Image, ImageOps
+
+ESC = b'\x1b'
+GS  = b'\x1d'
+
+CupsRas3 = namedtuple(
+    # Documentation at https://www.cups.org/doc/spec-raster.html
+    'CupsRas3',
+    'MediaClass MediaColor MediaType OutputType AdvanceDistance AdvanceMedia Collate CutMedia Duplex HWResolutionH '
+    'HWResolutionV ImagingBoundingBoxL ImagingBoundingBoxB ImagingBoundingBoxR ImagingBoundingBoxT '
+    'InsertSheet Jog LeadingEdge MarginsL MarginsB ManualFeed MediaPosition MediaWeight MirrorPrint '
+    'NegativePrint NumCopies Orientation OutputFaceUp PageSizeW PageSizeH Separations TraySwitch Tumble cupsWidth '
+    'cupsHeight cupsMediaType cupsBitsPerColor cupsBitsPerPixel cupsBitsPerLine cupsColorOrder cupsColorSpace '
+    'cupsCompression cupsRowCount cupsRowFeed cupsRowStep cupsNumColors cupsBorderlessScalingFactor cupsPageSizeW '
+    'cupsPageSizeH cupsImagingBBoxL cupsImagingBBoxB cupsImagingBBoxR cupsImagingBBoxT cupsInteger1 cupsInteger2 '
+    'cupsInteger3 cupsInteger4 cupsInteger5 cupsInteger6 cupsInteger7 cupsInteger8 cupsInteger9 cupsInteger10 '
+    'cupsInteger11 cupsInteger12 cupsInteger13 cupsInteger14 cupsInteger15 cupsInteger16 cupsReal1 cupsReal2 '
+    'cupsReal3 cupsReal4 cupsReal5 cupsReal6 cupsReal7 cupsReal8 cupsReal9 cupsReal10 cupsReal11 cupsReal12 '
+    'cupsReal13 cupsReal14 cupsReal15 cupsReal16 cupsString1 cupsString2 cupsString3 cupsString4 cupsString5 '
+    'cupsString6 cupsString7 cupsString8 cupsString9 cupsString10 cupsString11 cupsString12 cupsString13 cupsString14 '
+    'cupsString15 cupsString16 cupsMarkerType cupsRenderingIntent cupsPageSizeName'
+)
+
+def read_ras3(rdata):
+    if not rdata:
+        raise ValueError('No data received')
+
+    # Check for magic word (either big-endian or little-endian)
+    magic = unpack('@4s', rdata[0:4])[0]
+    if magic != b'RaS3' and magic != b'3SaR':
+        raise ValueError("This is not in RaS3 format")
+    rdata = rdata[4:]  # Strip magic word
+    pages = []
+
+    while rdata:  # Loop over all pages
+        struct_data = unpack(
+            '@64s 64s 64s 64s I I I I I II IIII I I I II I I I I I I I I II I I I I I I I I I I I I I '
+            'I I I f ff ffff IIIIIIIIIIIIIIII ffffffffffffffff 64s 64s 64s 64s 64s 64s 64s 64s 64s 64s '
+            '64s 64s 64s 64s 64s 64s 64s 64s 64s',
+            rdata[0:1796]
+        )
+        data = [
+            # Strip trailing null-bytes of strings
+            b.decode().rstrip('\x00') if isinstance(b, bytes) else b
+            for b in struct_data
+        ]
+        header = CupsRas3._make(data)
+
+        # Read image data of this page into a bytearray
+        imgdata = rdata[1796:1796 + (header.cupsWidth * header.cupsHeight * header.cupsBitsPerPixel // 8)]
+        pages.append((header, imgdata))
+
+        # Remove this page from the data stream, continue with the next page
+        rdata = rdata[1796 + (header.cupsWidth * header.cupsHeight * header.cupsBitsPerPixel // 8):]
+
+    return pages
+
+def printer_init(file):
+    file.write(bytes.fromhex('1f112400')) # This comes from sniffing traffic, I'm unsure what it does, but seems needed
+    file.write(ESC + b'@') # initialize printer
+
+def start_page(file, image):
+    file.write(GS + b'v0')   # GS v 0 : print raster bit image
+    # 0: normal, 1 double width, 2 double heigh, 3 quadruple
+    mode = 0
+    file.write(mode.to_bytes(1, 'little'))
+    # number of bytes / line
+    file.write(bytes_per_line(image).to_bytes(2, 'little'))
+    file.write(image.height.to_bytes(2, 'little'))
+
+def bytes_per_line(image):
+    return int((image.width + 7) / 8)
+
+pages = read_ras3(sys.stdin.buffer.read())
+
+for i, datatuple in enumerate(pages):
+    (header, imgdata) = datatuple
+
+    if header.cupsColorSpace != 0 or header.cupsNumColors != 1:
+        raise ValueError('Invalid color space, only monocolor supported')
+
+    feedLines = header.AdvanceDistance
+
+    im = Image.frombuffer(mode='L', data=imgdata,
+                          size=(header.cupsWidth, header.cupsHeight))
+    im = ImageOps.invert(im)
+    im = im.convert('1')
+    im = im.transpose(Image.ROTATE_90)
+
+    line = 0
+    with os.fdopen(sys.stdout.fileno(), "wb", closefd=False) as stdout:
+        printer_init(stdout)
+        start_page(stdout, im)
+        stdout.write(im.tobytes())
+        bpl = bytes_per_line(im)
+        stdout.write(bytes.fromhex("00"*bpl*feedLines)) # Feed lines manually
+


### PR DESCRIPTION
Based on the M02 driver, the repo in https://github.com/polskafan/phomemo_d30, and my own BT sniffing.

Main differences:
* The label sizes are of course different.
* The D30 seems to require a few initialization bytes, which I'm unsure what they do.
* The D30 needs the image rotated before printing.
* The justification code is not sent for the D30 (I don't have  an M02, so no idea what it does there).
* The D30 doesn't expect/require anything after 255 lines, we can just send the whole image.
* The feed lines code for the M02 instead caused a whole new (blank) label from being printed. Instead, we send the lines as just white bytes.

Tested by printing from Inkscape, and it works fine.
