### PR TITLE
Doodling around, mainly avoiding writing byte by byte on stdout.

### DIFF
--- a/tools/phomemo-filter.py
+++ b/tools/phomemo-filter.py
@@ -1,45 +1,56 @@
 #! /usr/bin/python3
 
-import getopt, sys, os
+import getopt
+import os
+import sys
 
 from PIL import Image
 
+
+def log(line):
+    sys.stderr.write(line + "\n")
+
+
+def write(data):
+    wrote = sys.stdout.buffer.write(data)
+    if wrote != len(data):
+        log(f"ERROR writing {data}")
+
+
 def print_header():
-    with os.fdopen(sys.stdout.fileno(), "wb", closefd=False) as stdout:
-        stdout.write(b'\x1b\x40\x1b\x61\x01\x1f\x11\x02\x04')
-    return
+    write(b'\x1b\x40\x1b\x61\x01\x1f\x11\x02\x04')
+
 
 def print_marker(lines=0x100):
-    with os.fdopen(sys.stdout.fileno(), "wb", closefd=False) as stdout:
-        stdout.write(0x761d.to_bytes(2, 'little'))
-        stdout.write(0x0030.to_bytes(2, 'little'))
-        stdout.write(0x0030.to_bytes(2, 'little'))
-        stdout.write((lines - 1).to_bytes(2, 'little'))
-    return
+    write(0x761d.to_bytes(2, 'little'))
+    write(0x0030.to_bytes(2, 'little'))
+    write(0x0030.to_bytes(2, 'little'))
+    write((lines - 1).to_bytes(2, 'little'))
+
 
 def print_footer():
-    with os.fdopen(sys.stdout.fileno(), "wb", closefd=False) as stdout:
-        stdout.write(b'\x1b\x64\x02')
-        stdout.write(b'\x1b\x64\x02')
-        stdout.write(b'\x1f\x11\x08')
-        stdout.write(b'\x1f\x11\x0e')
-        stdout.write(b'\x1f\x11\x07')
-        stdout.write(b'\x1f\x11\x09')
-    return
+    write(b'\x1b\x64\x02')
+    write(b'\x1b\x64\x02')
+    write(b'\x1f\x11\x08')
+    write(b'\x1f\x11\x0e')
+    write(b'\x1f\x11\x07')
+    write(b'\x1f\x11\x09')
+
 
 def print_line(image, line):
-    with os.fdopen(sys.stdout.fileno(), "wb", closefd=False) as stdout:
-        for x in range(int(image.width / 8)):
-            byte = 0
-            for bit in range(8):
-                if image.getpixel((x * 8 + bit, line)) == 0:
-                    byte |= 1 << (7 - bit)
-            # 0x0a breaks the rendering
-            # 0x0a alone is processed like LineFeed by the printe
-            if byte == 0x0a:
-                byte = 0x14
-            stdout.write(byte.to_bytes(1, 'little'))
-    return
+    data = bytearray()
+    for x in range(int(image.width / 8)):
+        byte = 0
+        for bit in range(8):
+            if image.getpixel((x * 8 + bit, line)) == 0:
+                byte |= 1 << (7 - bit)
+        # 0x0a breaks the rendering
+        # 0x0a alone is processed like LineFeed by the printer
+        if byte == 0x0a:
+            byte = 0x14
+        data.append(byte)
+    write(data)
+
 
 def usage():
     print("%s [-h|--help] filename" % (sys.argv[0]))
@@ -48,7 +59,7 @@ def usage():
 try:
     opts, args = getopt.getopt(sys.argv[1:], "h", ["help"])
 except getopt.error as err:
-    print (str(err))
+    print(str(err))
     usage()
     sys.exit(1)
 
@@ -74,19 +85,26 @@ except:
 if image.width > image.height:
     image = image.transpose(Image.ROTATE_90)
 
+log(f"Opened image of size {image.width}×{image.height}")
+
 # width 384 dots
 image = image.resize(size=(384, int(image.height * 384 / image.width)))
 
+log(f"Resized the image is {image.width}×{image.height}.")
+
 # black&white printer: dithering
 image = image.convert(mode='1')
+image.save("out.png")
 
 remaining = image.height
 line=0
+log("Sending header")
 print_header()
 while remaining > 0:
     lines = remaining
     if lines > 256:
         lines = 256
+    log(f"Sending {lines} lines...")
     print_marker(lines)
     remaining -= lines
     while lines > 0:


### PR DESCRIPTION
That's not much, just me reading the code, learning about bluetooth, removing unused `return None`, adding a bit of logging, trying to simplify.

But as I undersood late, the phomemo is sensible to how we flush: if I flush "too often"/"at bad moments" it won't understand what I'm writing, probably messing with its buffers and parsers.

The code before my modification was using apparently bloaty context-mangers using `closefd=False`, but I learnt that they had in fact a very interesting effect, maybe intentional: they were ensuring a flush at the end of the `with`. Leading to one flush for the headers, one flush per line, one flush per markers, kind of nice!

By trying to simplify this there's no longer "nice flush at specific points", just big 4k writes, maybe this is bad? Maybe this also can cause the internal buffers of the printer to go in bad states? I don't know.

From an strace point of view, the previous behavior was:

```strace
lseek(1, 0, SEEK_CUR)                   = 73545
write(1, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 48) = 48
fstat(1, {st_mode=S_IFREG|0664, st_size=73593, ...}) = 0
ioctl(1, TCGETS, 0x7ffcc4511d50)        = -1 ENOTTY (Ioctl() inapproprié pour un périphérique)
lseek(1, 0, SEEK_CUR)                   = 73593
write(1, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 48) = 48
fstat(1, {st_mode=S_IFREG|0664, st_size=73641, ...}) = 0
ioctl(1, TCGETS, 0x7ffcc4511d50)        = -1 ENOTTY (Ioctl() inapproprié pour un périphérique)
lseek(1, 0, SEEK_CUR)                   = 73641
write(1, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 48) = 48
fstat(1, {st_mode=S_IFREG|0664, st_size=73689, ...}) = 0
ioctl(1, TCGETS, 0x7ffcc4511d50)        = -1 ENOTTY (Ioctl() inapproprié pour un périphérique)
```

It is now:

```strace
write(1, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 4088) = 4088
write(1, "\0\0\0\0\0\0\0\0\0\7\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377"..., 4080) = 4080
write(1, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1\377\377\377\377\377\377\377\377\0\0\0"..., 4080) = 4080
```

so for a 800×200 file it was previously doing 7.8k syscalls at well defined points, down to 1.7k syscalls at buffer boundary.

I was not trying to optimize by lowering the number of syscalls, that's just a side-effect.
