### PR TITLE
tools: display the version from the command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ install:
 	install -Dm 0644 README.md -t $(DESTDIR)/usr/share/phomemo/
 	install -Dm 0644 LICENSE -t $(DESTDIR)/usr/share/phomemo/
 	cp -a images $(DESTDIR)/usr/share/phomemo/
+	PHOMEMO_VERSION=$(VERSION) make -C tools version
 	make -C tools install
 	make -C cups install
 	make -C glabels install

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,5 +1,10 @@
 all:
 
+version:
+ifdef PHOMEMO_VERSION
+	sed -e "s/@@VERSION@@/$(PHOMEMO_VERSION)/g" -i phomemo-filter.py
+endif
+
 install:
 	install -D phomemo-filter.py -t $(DESTDIR)/usr/share/phomemo/
 	install -D format-checker.py -t $(DESTDIR)/usr/share/phomemo/

--- a/tools/phomemo-filter.py
+++ b/tools/phomemo-filter.py
@@ -50,6 +50,7 @@ def print_line(image, line):
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--no-rotate", action="store_true", help="Disable auto-rotation of the image")
+parser.add_argument("-V", "--version", action="version", version=f"%(prog)s @@VERSION@@")
 parser.add_argument("file")
 
 args = parser.parse_args()


### PR DESCRIPTION
When installing tools, the version is replaced with the one in the Makefile. To display it, the `--version` option is available.