### PR TITLE
Add M835 thermal printer support (300 DPI, Bluetooth BLE+RFCOMM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Phomemo-tools
 
 This package is trying to provide tools to print pictures using
-the Phomemo M02, M02 Pro, M02S, M110, M120, M220 and T02 thermal printers from Linux.
+the Phomemo M02, M02 Pro, M02S, M110, M120, M220, T02 and M835 thermal printers from Linux.
 
 All the information here has been reverse-engineered sniffing
 the bluetooth packets emitted by the Android application.
@@ -495,3 +495,120 @@ Dumpping USB packets.
   0x1f 0xf0 0x05 0x00
   0x1f 0xf0 0x03 0x00
 ```
+
+## 6. Protocol for M835
+
+The M835 is a 300 DPI thermal printer with A4/Letter paper support.
+Unlike the M02 (203 DPI, 384 dots/line), the M835 operates at 300 DPI
+and supports variable paper widths up to 214mm (2528 dots).
+
+### 6.1. Bluetooth Architecture
+
+The M835 uses **dual-mode Bluetooth**:
+
+- **Discovery**: BLE (Bluetooth Low Energy) — the printer advertises as "M835"
+  but goes to sleep when idle to save battery. `bluetoothctl scan on` does NOT
+  find it. Use Python's `bleak` library for reliable BLE discovery.
+- **Connection**: Classic Bluetooth RFCOMM (Serial Port Profile)
+  - SPP UUID: `00001101-0000-1000-8000-00805f9b34fb`
+  - Channel: 1
+  - Service name: `JL_SPP` (Jieli Technology chip)
+
+### 6.2. HEADER
+
+```
+  0x1b 0x40      -> command ESC @: initialize printer
+  0x1f 0x11 0x02 0x04
+```
+
+### 6.3. BLOCK MARKER
+
+```
+  0x1d 0x76 0x30 -> command GS v 0 : print raster bit image
+  0x00              mode: 0 (normal), 1 (double width),
+                          2 (double-height), 3 (quadruple)
+  0xXX 0x00         16bit, little-endian: number of bytes / line
+  0xYY 0x00         16bit, little-endian: number of lines in the block (max 255)
+```
+
+The M835 uses the same GS v 0 command as the M02, but supports arbitrary
+line widths (must be divisible by 8). For 214mm paper at 300 DPI:
+- 214mm × 11.81 dots/mm ≈ 2528 dots → 316 bytes/line
+
+For images taller than 255 lines, send multiple block markers.
+
+### 6.4. FOOTER
+
+```
+  0x1b 0x64 0x02  -> ESC d: print and feed 2 lines
+  0x1b 0x64 0x02  -> ESC d: print and feed 2 lines
+  0x1f 0x11 0x08
+  0x1f 0x11 0x0e
+  0x1f 0x11 0x07
+  0x1f 0x11 0x09
+```
+
+### 6.5. FLOW CONTROL (critical)
+
+The M835 has a small internal buffer. Sending data too fast causes a timeout
+(Errno 110: Connection timed out). The working parameters are:
+
+- **Chunk size**: 256 bytes per `send()` call
+- **Delay**: 30ms between chunks
+- On buffer-full error: read `recv()` to drain, then retry with 3× delay
+
+Without flow control, sending a full-page image (~1MB) fails at ~16%.
+
+### 6.6. IMAGE
+
+Each line is N bytes long (N = width / 8), each bit is a pixel.
+At 300 DPI: 300 dots per inch = 11.81 dots per millimeter.
+1 = black (burn), 0 = white (skip), MSB first.
+
+### 6.7. Printer Status Response
+
+```
+  1a 3b 04 19 00 00 00  (7 bytes)
+```
+
+### 6.8. Bluetooth Usage
+
+```bash
+# Discover via BLE (requires bleak: pip3 install bleak)
+python3 -c "import asyncio; from bleak import BleakScanner; \
+devices = asyncio.run(BleakScanner.discover(timeout=10)); \
+[print(f'{d.name} at {d.address}') for d in devices if d.name and 'M835' in d.name.upper()]"
+
+# Pair and trust
+bluetoothctl pair FE:10:1D:EE:5F:C2
+bluetoothctl trust FE:10:1D:EE:5F:C2
+
+# Print (no rfcomm needed — uses Python's built-in bluetooth socket)
+python3 tools/phomemo-m835-bt.py image.png
+python3 tools/phomemo-m835-bt.py image.png --feed 40
+```
+
+No `rfcomm` bind is needed — the script uses Python's built-in
+`socket.AF_BLUETOOTH` with `BTPROTO_RFCOMM` directly.
+
+### 6.9. M835 vs M02 Comparison
+
+| Property | M02 | M835 |
+|----------|-----|------|
+| DPI | 203 | 300 |
+| Dots per line | 384 (48 bytes) | Variable (up to 2528, 316 bytes) |
+| Paper width | 48mm | Up to 214mm (A4/Letter) |
+| Discovery | Bluetooth Classic | BLE (sleeps when idle) |
+| Connection | RFCOMM channel 1 | RFCOMM channel 1 |
+| SPP UUID | 00001101 | 00001101 |
+| Protocol | ESC/POS raster (GS v 0) | ESC/POS raster (GS v 0) |
+| Flow control | Not required | 256-byte chunks, 30ms delay |
+
+### 6.10. Attribution
+
+Protocol reverse-engineered by Sean (battlemark-ai) and Mechanic
+(Hermes Agent, glm-5.2:cloud) on 2026-07-03. The Phomemo Android app
+(`com.quyin.phomemo`) was decompiled with jadx to confirm the
+protocol structure. The app uses BLE for discovery but Classic
+RFCOMM for all data transfer — the BLE connector classes in the APK
+are legacy code that is never instantiated.

--- a/tools/phomemo-m835-bt.py
+++ b/tools/phomemo-m835-bt.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""
+phomemo-m835-bt — Print to Phomemo M835 thermal printer via Bluetooth from Linux.
+
+The M835 uses BLE for discovery and Classic Bluetooth RFCOMM (SPP) for data
+transfer. The print protocol is ESC/POS raster (GS v 0), same as the M02 family,
+but at 300 DPI with wider paper support.
+
+Discovery: BLE (printer advertises as "M835")
+Connection: Classic BT RFCOMM, SPP UUID 00001101, channel 1
+Protocol: ESC/POS raster (GS v 0) with Phomemo header/footer
+Flow control: 256-byte chunks, 30ms delay (critical — buffer overflows otherwise)
+
+Tested on: Ubuntu 26.04, BlueZ 5.85, Python 3.14
+Printer: Phomemo M835-White-Phomemo
+
+Requirements:
+    - Python 3 (stdlib bluetooth socket — no PyBluez needed)
+    - Pillow (PIL) for image handling
+    - bleak (for BLE discovery, optional)
+    - BlueZ (bluetoothctl for pairing)
+
+Usage:
+    python3 phomemo-m835-bt.py image.png
+    python3 phomemo-m835-bt.py image.png --mac FE:10:1D:EE:5F:C2 --feed 40
+    python3 phomemo-m835-bt.py --discover
+
+Discovered by: Sean (battlemark-ai) and Mechanic (Hermes Agent, glm-5.2:cloud)
+Date: 2026-07-03
+"""
+
+import argparse
+import socket
+import sys
+import time
+from PIL import Image
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+PRINTER_MAC = "FE:10:1D:EE:5F:C2"  # Default M835 MAC (from QR code)
+RFCOMM_CHANNEL = 1                  # SPP channel (from sdptool)
+SPP_UUID = "00001101-0000-1000-8000-00805f9b34fb"
+
+# Flow control — critical for not overflowing the printer's buffer
+CHUNK_SIZE = 256       # bytes per write
+CHUNK_DELAY = 0.03     # 30ms between chunks
+
+# Printer: 300 DPI
+DPI = 300
+DOTS_PER_MM = DPI / 25.4  # ~11.81 dots/mm
+
+# ESC/POS protocol bytes (Phomemo M02-family variant)
+HEADER = b'\x1b\x40'           # ESC @ — initialize printer
+PHOMEMO_INIT = b'\x1f\x11\x02\x04'  # Phomemo-specific init sequence
+RASTER_CMD = b'\x1d\x76\x30'   # GS v 0 — print raster bit image
+FOOTER = (
+    b'\x1b\x64\x02'   # ESC d 2 — feed 2 lines
+    b'\x1b\x64\x02'   # ESC d 2 — feed 2 lines
+    b'\x1f\x11\x08'   # Phomemo footer
+    b'\x1f\x11\x0e'
+    b'\x1f\x11\x07'
+    b'\x1f\x11\x09'
+)
+
+
+# ── Image Processing ────────────────────────────────────────────────────────
+
+def load_image(path, width=None, threshold=128):
+    """
+    Load an image file and convert to 1-bit (black/white) for thermal printing.
+
+    Args:
+        path: Path to image file (PNG, JPG, etc.)
+        width: Target width in pixels. If None, uses image's native width
+               (rounded up to nearest multiple of 8).
+        threshold: Grayscale threshold (0-255). Pixels below this = black.
+
+    Returns:
+        PIL.Image in mode '1' (1-bit), width divisible by 8.
+    """
+    img = Image.open(path)
+
+    if img.mode != 'L':
+        img = img.convert('L')
+
+    if width:
+        ratio = width / img.width
+        new_height = int(img.height * ratio)
+        img = img.resize((width, new_height), Image.LANCZOS)
+
+    w, h = img.size
+    if w % 8 != 0:
+        new_w = ((w + 7) // 8) * 8
+        img = img.resize((new_w, h), Image.LANCZOS)
+
+    img = img.point(lambda p: 255 if p > threshold else 0, mode='1')
+
+    return img
+
+
+def image_to_escpos(img):
+    """
+    Convert a 1-bit PIL image to ESC/POS raster print data.
+
+    Uses GS v 0 command with Phomemo header/footer.
+    Splits into blocks of max 255 lines if image is tall.
+
+    Args:
+        img: PIL Image in mode '1' (width must be divisible by 8)
+
+    Returns:
+        bytes: Complete ESC/POS data stream ready to send to printer.
+    """
+    if img.mode != '1':
+        raise ValueError("Image must be in 1-bit mode")
+
+    width, height = img.size
+    bytes_per_line = width // 8
+
+    data = bytearray()
+    data.extend(HEADER)
+    data.extend(PHOMEMO_INIT)
+
+    pixels = list(img.getdata())
+
+    max_block = 255
+    remaining = height
+
+    while remaining > 0:
+        block_lines = min(remaining, max_block)
+        start_line = height - remaining
+
+        data.extend(RASTER_CMD)
+        data.append(0x00)  # mode: normal
+        data.extend(bytes_per_line.to_bytes(2, 'little'))
+        data.extend(block_lines.to_bytes(2, 'little'))
+
+        for y in range(start_line, start_line + block_lines):
+            for x_byte in range(bytes_per_line):
+                byte_val = 0
+                for bit in range(8):
+                    px = x_byte * 8 + bit
+                    if px < width:
+                        if pixels[y * width + px] == 0:  # black pixel
+                            byte_val |= (0x80 >> bit)
+                data.append(byte_val)
+
+        remaining -= block_lines
+
+    data.extend(FOOTER)
+
+    return bytes(data)
+
+
+def add_feed_space(data, width, feed_mm):
+    """
+    Append blank raster space for tear-off.
+
+    Args:
+        data: Existing ESC/POS bytearray
+        width: Image width in pixels (must be divisible by 8)
+        feed_mm: Blank space in millimeters
+
+    Returns:
+        bytearray with blank space appended
+    """
+    if feed_mm <= 0:
+        return data
+
+    feed_lines = int(feed_mm * DOTS_PER_MM)
+    bytes_per_line = width // 8
+
+    data = bytearray(data)
+    data.extend(RASTER_CMD)
+    data.append(0x00)
+    data.extend(bytes_per_line.to_bytes(2, 'little'))
+    data.extend(feed_lines.to_bytes(2, 'little'))
+    data.extend(b'\x00' * (bytes_per_line * feed_lines))
+
+    return data
+
+
+# ── Bluetooth ────────────────────────────────────────────────────────────────
+
+def discover_printer(name="M835", timeout=15):
+    """
+    Scan for the printer via BLE using bleak.
+
+    Returns:
+        MAC address string if found, None if not found.
+    """
+    try:
+        from bleak import BleakScanner
+    except ImportError:
+        print("bleak not installed — install with: pip3 install bleak")
+        return None
+
+    import asyncio
+
+    async def scan():
+        print(f"Scanning for '{name}' via BLE ({timeout}s)...")
+        devices = await BleakScanner.discover(timeout=timeout)
+        for d in devices:
+            if d.name and name.upper() in d.name.upper():
+                print(f"  Found: {d.name} at {d.address}")
+                return d.address
+        print(f"  '{name}' not found in scan")
+        return None
+
+    return asyncio.run(scan())
+
+
+def pair_printer(mac):
+    """
+    Pair and trust the printer via bluetoothctl.
+    Safe to call if already paired — it will just confirm.
+    """
+    import subprocess
+
+    print(f"Pairing {mac}...")
+    r = subprocess.run(['bluetoothctl', 'pair', mac],
+                       capture_output=True, text=True, timeout=15)
+    if 'Pairing successful' in r.stdout or 'already paired' in r.stdout.lower():
+        print("  Paired.")
+    else:
+        print(f"  Pair result: {r.stdout.strip()}")
+
+    print(f"Trusting {mac}...")
+    r = subprocess.run(['bluetoothctl', 'trust', mac],
+                       capture_output=True, text=True, timeout=10)
+    print(f"  Trusted.")
+
+    return True
+
+
+def send_to_printer(data, mac=PRINTER_MAC, channel=RFCOMM_CHANNEL,
+                    chunk_size=CHUNK_SIZE, delay=CHUNK_DELAY):
+    """
+    Send ESC/POS data to the printer via Classic Bluetooth RFCOMM.
+
+    Uses Python's built-in bluetooth socket (AF_BLUETOOTH, BTPROTO_RFCOMM).
+    No PyBluez required.
+
+    Args:
+        data: ESC/POS byte data
+        mac: Printer MAC address
+        channel: RFCOMM channel (1 for SPP)
+        chunk_size: Bytes per write (flow control)
+        delay: Seconds between writes (flow control)
+
+    Returns:
+        True if all data sent successfully, False on error.
+    """
+    total = len(data)
+    print(f"Connecting to {mac} channel {channel}...")
+
+    sock = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_STREAM,
+                         socket.BTPROTO_RFCOMM)
+    sock.settimeout(30)
+
+    try:
+        sock.connect((mac, channel))
+        print(f"Connected! Sending {total} bytes ({total/1024:.1f} KB)...")
+
+        sent = 0
+        for i in range(0, total, chunk_size):
+            chunk = data[i:i + chunk_size]
+            try:
+                sock.send(chunk)
+                sent += len(chunk)
+                pct = sent * 100 // total
+                if pct % 10 == 0 and sent > 0:
+                    print(f"  {sent}/{total} bytes ({pct}%)")
+                time.sleep(delay)
+            except Exception as e:
+                # Buffer full — drain and retry
+                print(f"  Buffer full at {sent} bytes, waiting...")
+                sock.settimeout(2)
+                try:
+                    sock.recv(1024)
+                except socket.timeout:
+                    pass
+                sock.settimeout(30)
+                try:
+                    sock.send(chunk)
+                    sent += len(chunk)
+                    time.sleep(delay * 3)  # Longer delay after recovery
+                except Exception as e2:
+                    print(f"  Send failed: {e2}")
+                    return False
+
+        print(f"Sent {sent}/{total} bytes ✓")
+
+        # Read status response
+        sock.settimeout(5)
+        try:
+            resp = sock.recv(1024)
+            print(f"Printer response: {resp.hex()} ({len(resp)} bytes)")
+        except socket.timeout:
+            print("No response (normal for some commands)")
+
+        sock.close()
+        return True
+
+    except Exception as e:
+        print(f"Connection error: {e}")
+        try:
+            sock.close()
+        except:
+            pass
+        return False
+
+
+# ── Main ────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Print an image to Phomemo M835 via Bluetooth')
+    parser.add_argument('image', nargs='?',
+                        help='Image file to print (PNG, JPG, etc.)')
+    parser.add_argument('--mac', default=PRINTER_MAC,
+                        help=f'Printer MAC address (default: {PRINTER_MAC})')
+    parser.add_argument('--width', type=int, default=None,
+                        help='Output width in pixels (default: native image width)')
+    parser.add_argument('--feed', type=int, default=40,
+                        help='Blank space after print in mm (default: 40)')
+    parser.add_argument('--threshold', type=int, default=128,
+                        help='B/W threshold 0-255 (default: 128, lower=darker)')
+    parser.add_argument('--discover', action='store_true',
+                        help='Scan for printer via BLE and exit')
+    parser.add_argument('--pair-only', action='store_true',
+                        help='Pair printer and exit (no print)')
+
+    args = parser.parse_args()
+
+    if args.discover:
+        mac = discover_printer()
+        if mac:
+            print(f"\nPrinter found at {mac}")
+            print(f"To pair: bluetoothctl pair {mac}")
+        else:
+            print("\nPrinter not found. Make sure it's powered on (green light).")
+        return
+
+    if args.pair_only:
+        pair_printer(args.mac)
+        return
+
+    if not args.image:
+        parser.print_help()
+        print("\nError: image file required for printing")
+        sys.exit(1)
+
+    print(f"Loading {args.image}...")
+    img = load_image(args.image, width=args.width, threshold=args.threshold)
+    print(f"  Image: {img.size[0]}x{img.size[1]}px, {img.size[0]//8} bytes/line")
+
+    print("Converting to ESC/POS raster...")
+    data = image_to_escpos(img)
+    print(f"  ESC/POS data: {len(data)} bytes ({len(data)/1024:.1f} KB)")
+
+    if args.feed > 0:
+        data = add_feed_space(data, img.size[0], args.feed)
+        feed_lines = int(args.feed * DOTS_PER_MM)
+        print(f"  Added {args.feed}mm ({feed_lines} lines) tear-off space")
+
+    success = send_to_printer(data, mac=args.mac)
+
+    if success:
+        print("\n✓ Print complete!")
+    else:
+        print("\n✗ Print failed!")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What This Adds

Support for the **Phomemo M835** thermal printer — a 300 DPI, A4/Letter-width thermal printer with Bluetooth connectivity.

This is the first known Linux Bluetooth implementation for the M835. It is not currently listed as supported by phomemo-tools or any other open-source project.

## Files Added

- **usage: phomemo-m835-bt.py [-h] [--mac MAC] [--width WIDTH] [--feed FEED]
                          [--threshold THRESHOLD] [--discover] [--pair-only]
                          [image]

Print an image to Phomemo M835 via Bluetooth

positional arguments:
  image                 Image file to print (PNG, JPG, etc.)

options:
  -h, --help            show this help message and exit
  --mac MAC             Printer MAC address (default: FE:10:1D:EE:5F:C2)
  --width WIDTH         Output width in pixels (default: native image width)
  --feed FEED           Blank space after print in mm (default: 40)
  --threshold THRESHOLD
                        B/W threshold 0-255 (default: 128, lower=darker)
  --discover            Scan for printer via BLE and exit
  --pair-only           Pair printer and exit (no print)

Error: image file required for printing** — Standalone Bluetooth print script
  - BLE discovery via  (printer advertises as "M835")
  - Classic RFCOMM connection (SPP UUID 00001101, channel 1)
  - ESC/POS raster protocol (GS v 0) — same as M02 family
  - **Flow control**: 256-byte chunks, 30ms delay (critical — buffer overflows without it)
  - Variable paper width support (up to 214mm / 2528px at 300 DPI)
  - Optional tear-off space (`--feed MM`)
  - No  bind needed — uses Python's built-in 

- **README.md** — Added Section 6: Protocol for M835
  - Bluetooth architecture (dual-mode: BLE discovery + Classic RFCOMM data)
  - Protocol details (header, block marker, footer, image format)
  - Flow control requirements
  - M835 vs M02 comparison table
  - Usage examples

## Key Findings

The M835 uses a **dual-mode Bluetooth** design that was the main challenge:

1. **Discovery**: The printer advertises via BLE as "M835" but goes to sleep when idle (battery saving). SetDiscoveryFilter success does **not** find it. Python's  library is required for reliable BLE discovery.

2. **Connection**: Despite BLE discovery, data transfer uses **Classic Bluetooth RFCOMM** (Serial Port Profile) — same SPP UUID and channel 1 as the M02.

3. **Protocol**: ESC/POS raster () with the same Phomemo header/footer bytes as the M02 family. The difference is 300 DPI (vs 203 DPI) and variable paper width (vs fixed 48mm).

4. **Flow control**: The M835 has a small internal buffer. Without pacing (256-byte chunks, 30ms delay), sending a full-page image (~1MB) fails with  at ~16%.

## How It Was Reverse-Engineered

The Phomemo Android app () was decompiled with . Key findings from the decompiled code:

- The app uses  (BLE) for discovery
- All printer models connect via  with SPP UUID (Classic RFCOMM)
- BLE GATT connector classes exist in the APK but are **never instantiated** — legacy code
- M835 model constant:  field 
- Connection class:  (Classic BT socket with RFCOMM)

## Verification

Tested on Ubuntu 26.04, BlueZ 5.85, Python 3.14. Successfully printed text and images via Bluetooth from Linux. Printer responds with status packet  on successful commands.

## Attribution

Protocol reverse-engineered by **Sean** (battlemark-ai) and **Mechanic** (Hermes Agent, glm-5.2:cloud) on 2026-07-03.